### PR TITLE
fix/gs-configure-search

### DIFF
--- a/scripts/gs-bulk-import-request-FHIRIZED-GTEX.sh
+++ b/scripts/gs-bulk-import-request-FHIRIZED-GTEX.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Bucket: fhir-aggregator-public
+# Project: FHIRIZED-GTEX
+# Generation date: 2025-03-19T17:11:25.546467
+set -euo pipefail
+: "${FHIR_STORE_ID:?Need to set FHIR_STORE_ID}"
+: "${DATASET_ID:?Need to set DATASET_ID}"
+: "${LOCATION:?Need to set LOCATION}"
+gcloud healthcare fhir-stores import gcs $FHIR_STORE_ID --dataset=$DATASET_ID --location=$LOCATION --content-structure=resource --async --gcs-uri=gs://fhir-aggregator-public/FHIRIZED-GTEX/META/DocumentReference.ndjson
+gcloud healthcare fhir-stores import gcs $FHIR_STORE_ID --dataset=$DATASET_ID --location=$LOCATION --content-structure=resource --async --gcs-uri=gs://fhir-aggregator-public/FHIRIZED-GTEX/META/Observation.ndjson
+gcloud healthcare fhir-stores import gcs $FHIR_STORE_ID --dataset=$DATASET_ID --location=$LOCATION --content-structure=resource --async --gcs-uri=gs://fhir-aggregator-public/FHIRIZED-GTEX/META/Patient.ndjson
+gcloud healthcare fhir-stores import gcs $FHIR_STORE_ID --dataset=$DATASET_ID --location=$LOCATION --content-structure=resource --async --gcs-uri=gs://fhir-aggregator-public/FHIRIZED-GTEX/META/ResearchStudy.ndjson
+gcloud healthcare fhir-stores import gcs $FHIR_STORE_ID --dataset=$DATASET_ID --location=$LOCATION --content-structure=resource --async --gcs-uri=gs://fhir-aggregator-public/FHIRIZED-GTEX/META/ResearchSubject.ndjson
+gcloud healthcare fhir-stores import gcs $FHIR_STORE_ID --dataset=$DATASET_ID --location=$LOCATION --content-structure=resource --async --gcs-uri=gs://fhir-aggregator-public/FHIRIZED-GTEX/META/ServiceRequest.ndjson
+gcloud healthcare fhir-stores import gcs $FHIR_STORE_ID --dataset=$DATASET_ID --location=$LOCATION --content-structure=resource --async --gcs-uri=gs://fhir-aggregator-public/FHIRIZED-GTEX/META/Specimen.ndjson

--- a/scripts/gs-bulk-import-request-FHIRIZED-ICGC.sh
+++ b/scripts/gs-bulk-import-request-FHIRIZED-ICGC.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Bucket: fhir-aggregator-public
+# Project: FHIRIZED-ICGC
+# Generation date: 2025-03-19T17:43:08.728042
+set -euo pipefail
+: "${FHIR_STORE_ID:?Need to set FHIR_STORE_ID}"
+: "${DATASET_ID:?Need to set DATASET_ID}"
+: "${LOCATION:?Need to set LOCATION}"
+gcloud healthcare fhir-stores import gcs $FHIR_STORE_ID --dataset=$DATASET_ID --location=$LOCATION --content-structure=resource --async --gcs-uri=gs://fhir-aggregator-public/FHIRIZED-ICGC/META/Condition.ndjson
+gcloud healthcare fhir-stores import gcs $FHIR_STORE_ID --dataset=$DATASET_ID --location=$LOCATION --content-structure=resource --async --gcs-uri=gs://fhir-aggregator-public/FHIRIZED-ICGC/META/DocumentReference.ndjson
+gcloud healthcare fhir-stores import gcs $FHIR_STORE_ID --dataset=$DATASET_ID --location=$LOCATION --content-structure=resource --async --gcs-uri=gs://fhir-aggregator-public/FHIRIZED-ICGC/META/Observation.ndjson
+gcloud healthcare fhir-stores import gcs $FHIR_STORE_ID --dataset=$DATASET_ID --location=$LOCATION --content-structure=resource --async --gcs-uri=gs://fhir-aggregator-public/FHIRIZED-ICGC/META/Patient.ndjson
+gcloud healthcare fhir-stores import gcs $FHIR_STORE_ID --dataset=$DATASET_ID --location=$LOCATION --content-structure=resource --async --gcs-uri=gs://fhir-aggregator-public/FHIRIZED-ICGC/META/ResearchStudy.ndjson
+gcloud healthcare fhir-stores import gcs $FHIR_STORE_ID --dataset=$DATASET_ID --location=$LOCATION --content-structure=resource --async --gcs-uri=gs://fhir-aggregator-public/FHIRIZED-ICGC/META/ResearchSubject.ndjson
+gcloud healthcare fhir-stores import gcs $FHIR_STORE_ID --dataset=$DATASET_ID --location=$LOCATION --content-structure=resource --async --gcs-uri=gs://fhir-aggregator-public/FHIRIZED-ICGC/META/ServiceRequest.ndjson
+gcloud healthcare fhir-stores import gcs $FHIR_STORE_ID --dataset=$DATASET_ID --location=$LOCATION --content-structure=resource --async --gcs-uri=gs://fhir-aggregator-public/FHIRIZED-ICGC/META/Specimen.ndjson

--- a/scripts/gs-configure-search.sh
+++ b/scripts/gs-configure-search.sh
@@ -4,6 +4,12 @@ set -euo pipefail
 : "${DATASET_ID:?Need to set DATASET_ID}"
 : "${LOCATION:?Need to set LOCATION}"
 
+# Note: The configureSearch call operates as a 'last-one-wins'
+# operation.  This means that if you call it multiple times with
+# different canonicalUrls values, the last call will be the one that is used.
+# This is why we include all of the canonicalUrls in a single call.
+
+
 curl -X POST     -H "Authorization: Bearer $(gcloud auth application-default print-access-token)"     -H "Content-Type: application/json; charset=utf-8"     --data '{
         "canonicalUrls": [
           "http://fhir-aggregator.org/fhir/SearchParameter/bodystructure-part-of-study",
@@ -20,17 +26,12 @@ curl -X POST     -H "Authorization: Bearer $(gcloud auth application-default pri
           "http://fhir-aggregator.org/fhir/SearchParameter/researchstudy-part-of-study",
           "http://fhir-aggregator.org/fhir/SearchParameter/researchsubject-part-of-study",
           "http://fhir-aggregator.org/fhir/SearchParameter/servicerequest-part-of-study",
-          "http://fhir-aggregator.org/fhir/SearchParameter/specimen-part-of-study"
-        ],
-    }'     "https://healthcare.googleapis.com/v1beta1/projects/$PROJECT_ID/locations/$LOCATION/datasets/$DATASET_ID/fhirStores/$FHIR_STORE_ID:configureSearch"
-
-
-curl -X POST     -H "Authorization: Bearer $(gcloud auth application-default print-access-token)"     -H "Content-Type: application/json; charset=utf-8"     --data '{
-        "canonicalUrls": [
+          "http://fhir-aggregator.org/fhir/SearchParameter/specimen-part-of-study",
           "http://hl7.org/fhir/us/core/SearchParameter/us-core-ethnicity",
           "http://hl7.org/fhir/SearchParameter/patient-extensions-Patient-age",
           "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
           "http://hl7.org/fhir/us/core/SearchParameter/us-core-race"
-        ]
+
+        ],
     }'     "https://healthcare.googleapis.com/v1beta1/projects/$PROJECT_ID/locations/$LOCATION/datasets/$DATASET_ID/fhirStores/$FHIR_STORE_ID:configureSearch"
 

--- a/scripts/gs-import-all.sh
+++ b/scripts/gs-import-all.sh
@@ -4,6 +4,8 @@ scripts/gs-bulk-import-request-FHIRIZED-CELLOSAURUS.sh
 scripts/gs-bulk-import-request-FHIRIZED-GDC.sh
 scripts/gs-bulk-import-request-FHIRIZED-HTAN.sh
 scripts/gs-bulk-import-request-FHIRIZED-1KGENOMES.sh
+scripts/gs-bulk-import-request-FHIRIZED-GTEX.sh
+scripts/gs-bulk-import-request-FHIRIZED-ICGC.sh
 scripts/gs-bulk-import-request-PATCHES.sh
 while true; do
   result=$(gcloud healthcare operations list --dataset=$DATASET_ID --location=$LOCATION --filter 'done!=true' --format json)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,45 @@
+import pytest
+
+
+@pytest.fixture
+def fhir_base_urls():
+    """Return a list of FHIR base URLs."""
+    return [
+        "https://google-fhir.test-fhir-aggregator.org",
+        "https://google-fhir.fhir-aggregator.org"
+    ]
+
+
+@pytest.fixture
+def expected_part_of_study_search_parameters():
+    """Return a list of expected part-of-study search parameters."""
+    return ['BodyStructure.part-of-study', 'Condition.part-of-study', 'DocumentReference.part-of-study',
+            'Encounter.part-of-study', 'Group.part-of-study', 'ImagingStudy.part-of-study', 'Medication.part-of-study',
+            'MedicationAdministration.part-of-study', 'Observation.part-of-study', 'Patient.part-of-study',
+            'Procedure.part-of-study', 'ResearchStudy.part-of-study', 'ResearchSubject.part-of-study',
+            'ServiceRequest.part-of-study', 'Specimen.part-of-study']
+
+
+@pytest.fixture
+def expected_search_definition_urls():
+    return """
+http://hl7.org/fhir/SearchParameter/patient-extensions-Patient-age
+http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex
+http://hl7.org/fhir/us/core/SearchParameter/us-core-ethnicity
+http://hl7.org/fhir/us/core/SearchParameter/us-core-race
+http://fhir-aggregator.org/fhir/SearchParameter/bodystructure-part-of-study
+http://fhir-aggregator.org/fhir/SearchParameter/condition-part-of-study
+http://fhir-aggregator.org/fhir/SearchParameter/documentreference-part-of-study
+http://fhir-aggregator.org/fhir/SearchParameter/encounter-part-of-study
+http://fhir-aggregator.org/fhir/SearchParameter/group-part-of-study
+http://fhir-aggregator.org/fhir/SearchParameter/imagingstudy-part-of-study
+http://fhir-aggregator.org/fhir/SearchParameter/medication-part-of-study
+http://fhir-aggregator.org/fhir/SearchParameter/medicationadministration-part-of-study
+http://fhir-aggregator.org/fhir/SearchParameter/observation-part-of-study
+http://fhir-aggregator.org/fhir/SearchParameter/patient-part-of-study
+http://fhir-aggregator.org/fhir/SearchParameter/procedure-part-of-study
+http://fhir-aggregator.org/fhir/SearchParameter/researchstudy-part-of-study
+http://fhir-aggregator.org/fhir/SearchParameter/researchsubject-part-of-study
+http://fhir-aggregator.org/fhir/SearchParameter/servicerequest-part-of-study
+http://fhir-aggregator.org/fhir/SearchParameter/specimen-part-of-study
+    """.split()

--- a/tests/integration/test_search_parameters.py
+++ b/tests/integration/test_search_parameters.py
@@ -1,0 +1,33 @@
+import requests
+
+
+def test_search_parameters(fhir_base_urls, expected_part_of_study_search_parameters):
+    """Test search parameters."""
+    for base_url in fhir_base_urls:
+        url = f"{base_url}/metadata"
+        search_includes = []
+        response = requests.get(url)
+        response.raise_for_status()
+        metadata = response.json()
+        for rest in metadata['rest']:
+            for resource in rest['resource']:
+                for search_include in resource.get('searchInclude', []):
+                    search_includes.append(search_include)
+        actual = sorted([_ for _ in search_includes if 'part-of-study' in _])
+        assert actual == expected_part_of_study_search_parameters, f"Unexpected search parameters: {actual} in {base_url}"
+
+
+def test_search_definition_urls(fhir_base_urls, expected_search_definition_urls):
+    for base_url in fhir_base_urls:
+        url = f"{base_url}/metadata"
+        search_includes = []
+        response = requests.get(url)
+        response.raise_for_status()
+        metadata = response.json()
+        """searchParam"""
+        actual_definitions = []
+        for rest in metadata['rest']:
+            for resource in rest['resource']:
+                for search_param in resource.get('searchParam', []):
+                    actual_definitions.append(search_param['definition'])
+        assert set(actual_definitions).issuperset(set(expected_search_definition_urls))


### PR DESCRIPTION
This PR:
* ensures a single configureSearch with a single set of canonicalUrls configured
* adds tests/integration to test deployed servers
* new: adds [FHIRIZED-GTEX, ICGC] 

```
# Note: The configureSearch call operates as a 'last-one-wins'
# operation.  This means that if you call it multiple times with
# different canonicalUrls values, the last call will be the one that is used.
# This is why we include all of the canonicalUrls in a single call.

# from https://cloud.google.com/healthcare-api/docs/reference/rest/v1beta1/projects.locations.datasets.fhirStores/configureSearch

Configure the search parameters for the FHIR store and reindex resources in the FHIR store according to the defined search parameters. The search parameters provided in this request will replace any previous search configuration.


```